### PR TITLE
Added muted hover state to typography component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinox-fund/equinox-lib",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Equinox components",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/common/Typography/styles.ts
+++ b/src/components/common/Typography/styles.ts
@@ -49,6 +49,7 @@ const styles = ({
     &:hover {
       ${tw`text-neutral-silver`}
       ${tw`cursor-pointer`}
+      ${color === 'muted' && tw`text-secondary`};
     }
   }
 `


### PR DESCRIPTION
The hover style now comes from the Typography component for the legal links in the image below.

![Screenshot 2022-03-10 at 17 39 50](https://user-images.githubusercontent.com/4044067/157644878-01fe7e2f-11c5-4a34-b804-8ad8ef1df1d6.png)
